### PR TITLE
Bug in wall clock time formatter

### DIFF
--- a/web/src/main/webapp/custom_ofmeet.js
+++ b/web/src/main/webapp/custom_ofmeet.js
@@ -556,8 +556,8 @@ var ofmeet = (function(of)
             ++totalSeconds;
 
             const secs = pad(totalSeconds % 60);
-            const mins = pad(parseInt(totalSeconds / 60));
-            const hrs = pad(parseInt(totalSeconds / 3600, 10));
+            const mins = pad(parseInt((totalSeconds / 60) % 60));
+            const hrs = pad(parseInt((totalSeconds / 3600) % 24, 10));
 
             textElem.textContent = hrs + ":" + mins + ":" + secs;
             setTimeout(updateClock, 1000);


### PR DESCRIPTION
The current formatter is buggy; it shows 1:63:45 instead of 1:03:45 because of missing modulo operations.