### PR TITLE
Update ConfigServlet.java

### DIFF
--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
@@ -84,6 +84,7 @@ public class ConfigServlet extends HttpServlet
 
 
             int minHDHeight = JiveGlobals.getIntProperty( "org.jitsi.videobridge.ofmeet.min.hdheight", 540 );
+            String defaultLanguage = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.default.language", null );
             boolean useNicks = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.usenicks", false );
             boolean webinar = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.webinar", false );
             boolean useIPv6 = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.useipv6", false );
@@ -146,6 +147,10 @@ public class ConfigServlet extends HttpServlet
             }
             config.put( "enforcedBridge", "jitsi-videobridge." + xmppDomain );
             config.put( "useStunTurn", useStunTurn );
+            if ( defaultLanguage != null && !defaultLanguage.trim().istEmpty() )
+            {
+                config.put( "defaultLanguage", defaultLanguage.trim() );
+            }
             config.put( "webinar", webinar );
             config.put( "useIPv6", useIPv6 );
             config.put( "useNicks", useNicks );

--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
@@ -147,7 +147,7 @@ public class ConfigServlet extends HttpServlet
             }
             config.put( "enforcedBridge", "jitsi-videobridge." + xmppDomain );
             config.put( "useStunTurn", useStunTurn );
-            if ( defaultLanguage != null && !defaultLanguage.trim().istEmpty() )
+            if ( defaultLanguage != null && !defaultLanguage.trim().isEmpty() )
             {
                 config.put( "defaultLanguage", defaultLanguage.trim() );
             }


### PR DESCRIPTION
Allow setting of the default language of the OFMeet client UI. 
Make `defaultLanguage` configurable by `org.jitsi.videobridge.ofmeet.default.language`. This may be included in the Plugin Configure UI later on.

Purpose and syntax taken from https://ffmuc.net/wiki/doku.php?id=knb:meet-server