### PR TITLE
Update custom_ofmeet.css

### DIFF
--- a/web/src/main/webapp/custom_ofmeet.css
+++ b/web/src/main/webapp/custom_ofmeet.css
@@ -9,11 +9,25 @@
 }
 
 .raisehandindicator {
-animation-name: raisehand;
-animation-duration: 2s;
-animation-direction: alternate;
-animation-delay: 5s;
-animation-iteration-count: infinite;
+  animation-name: raisehand;
+  animation-duration: 2s;
+  animation-direction: alternate;
+  animation-delay: 5s;
+  animation-iteration-count: infinite;
+}
+
+/* >>> */
+
+
+/* <<<
+ * 20200522/G.Jaekel@DNB.DE     On small browser windows, the left toolbar renders to wide. Make it wrapping around.
+ */
+
+.new-toolbox {
+  bottom:calc((40px * 3) * -1); /* was: calc((40px * 2) * -1); */
+}
+.button-group-left {
+  flex-wrap: wrap;
 }
 
 /* >>> */


### PR DESCRIPTION
On small browser windows, the left toolbar renders to wide. This is caused by the additional items for the Contact Manager and the Breakout Rooms. Make it wrapping around.