### PR TITLE
Update logging.properties for JiCoFo

### DIFF
--- a/offocus/classes/jicofo/logging.properties
+++ b/offocus/classes/jicofo/logging.properties
@@ -46,6 +46,9 @@ io.sentry.jul.SentryHandler.level=WARNING
 
 # to disable double timestamps in syslog uncomment next line
 #net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=true
+# OFMeet: avoid double-timestamping
+net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=false
+
 
 # uncomment to see how Jicofo talks to the JVB
 #org.jitsi.impl.protocol.xmpp.colibri.level=ALL


### PR DESCRIPTION
avoid double-timestamping

Fixes #97 for JiCoFo.