### PR TITLE
Update logging.properties for JVB2

### DIFF
--- a/ofmeet/classes/jvb/logging.properties
+++ b/ofmeet/classes/jvb/logging.properties
@@ -27,6 +27,12 @@ io.sentry.jul.SentryHandler.level=WARNING
 
 # to disable double timestamps in syslog uncomment next line
 #net.java.sip.communicator.util.ScLogFormatter.disableTimestamp=true
+# ^ this is the wrong class, one have to use ...
+#org.jitsi.utils.logging2.JitsiLogFormatter.disableTimestamp=true
+# OFMeet: avoid double-timestamping
+org.jitsi.utils.logging2.JitsiLogFormatter.disableTimestamp=true
+
+
 
 # time series logging
 java.util.logging.SimpleFormatter.format= %5$s%n


### PR DESCRIPTION
avoid double-timestamping

Fixes #97 for JVB2