### PR TITLE
Update custom_ofmeet.js

### DIFF
--- a/web/src/main/webapp/custom_ofmeet.js
+++ b/web/src/main/webapp/custom_ofmeet.js
@@ -439,7 +439,7 @@ var ofmeet = (function(of)
           audioTemporaryUnmuted = !audioTemporaryUnmuted;
           console.debug("audio " + (audioTemporaryUnmuted ? "temporary un" : "re") + "muted");
         }
-        setTimeout(lostAudioWorkaround, audioTemporaryUnmuted ? 1000 : lostAudioWorkaroundInterval);
+        setTimeout(lostAudioWorkaround, audioTemporaryUnmuted ? 1 : lostAudioWorkaroundInterval);
     }
 
 


### PR DESCRIPTION
Make audio toggling as short as possible again to keep privacy;  un-muting of 1s will dispose recognizable contents to the other participants.

I already suggest this with my first contribution, but you (Dele) changed it for some reason unknown to me.