### PR TITLE
Update custom_ofmeet.js

### DIFF
--- a/web/src/main/webapp/custom_ofmeet.js
+++ b/web/src/main/webapp/custom_ofmeet.js
@@ -32,6 +32,7 @@ var ofmeet = (function(of)
     let clockTrack = {start: 0, stop: 0, joins: 0, leaves: 0}, handsRaised = 0;
     let tags = {location: "", date: (new Date()).toISOString().split('T')[0], subject: "", host: "", activity: ""};
     let audioTemporaryUnmuted = false, cursorShared = false;
+    let breakoutIconVisible = false;
     //-------------------------------------------------------
     //
     //  window events
@@ -2152,19 +2153,21 @@ var ofmeet = (function(of)
         }
 
         console.debug("postJoinSetup");
-
+        
         // fake the interaction
         APP.conference.commands.addCommandListener("___FAKE_INTERACTION", function()
         {
-            if (interfaceConfig.OFMEET_ENABLE_BREAKOUT && APP.conference._room.isModerator())
+            if (interfaceConfig.OFMEET_ENABLE_BREAKOUT && APP.conference._room.isModerator() && !breakoutIconVisible)
             {
                 breakoutRooms();
+                breakoutIconVisible = true;
             }
        });
 
         if (interfaceConfig.OFMEET_ENABLE_BREAKOUT && APP.conference._room.isModerator())
         {
             breakoutRooms();
+            breakoutIconVisible= true;
         }
         else {
             APP.conference.commands.sendCommandOnce("___FAKE_INTERACTION", {value: !0});


### PR DESCRIPTION
While the #129 fixed the moderator rights and breakout icon problem now as I could see the problem is duplicate icons getting added every time moderator access if given to the user or even if its given to other users.

Creating `breakoutIconVisible` and setting it to `false` initially, then after first breakout it will be turned `true`, to stop it to keep adding the breakout icon on every time moderator rights are given to owner of room.