### PR TITLE
Update InterfaceConfigServlet.java

### DIFF
--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
@@ -83,6 +83,7 @@ public class InterfaceConfigServlet extends HttpServlet
             config.put( "RANDOM_AVATAR_URL_SUFFIX",              JiveGlobals.getProperty(        "org.jitsi.videobridge.ofmeet.random.avatar.url.suffix",      ""                  ) );
             config.put( "ENABLE_FEEDBACK_ANIMATION",             JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.feedback_animation",     false               ) );
             config.put( "DISABLE_FOCUS_INDICATOR",               JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.disable.focus.indicator",       false               ) );
+            config.put( "DISABLE_VIDEO_BACKGROUND",              JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.disable.video_background",      false               ) );
             config.put( "ACTIVE_SPEAKER_AVATAR_SIZE",            JiveGlobals.getIntProperty(     "org.jitsi.videobridge.ofmeet.active.speaker.avatarsize",     100                 ) );
 
             config.put( "OFMEET_RECORD_CONFERENCE",              JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.conference.recording",          true                ) );


### PR DESCRIPTION
Make `DISABLE_VIDEO_BACKGROUND` configurable by the System Property `org.jitsi.videobridge.ofmeet.disable.video_background`

Disabling the video background will remove flickering on fine-lined screen shares.