### PR TITLE
Update WellKnownHostMeta.java

### DIFF
--- a/pade/src/java/org/ifsoft/sso/WellKnownHostMeta.java
+++ b/pade/src/java/org/ifsoft/sso/WellKnownHostMeta.java
@@ -30,7 +30,7 @@ public class WellKnownHostMeta extends HttpServlet
 
         try {
             writeHeader(response);
-            String server = XMPPServer.getInstance().getServerInfo().getHostname() + ":" + JiveGlobals.getProperty("httpbind.port.secure", "7443");
+            final String server = XMPPServer.getInstance().getServerInfo().getHostname() + ":" + JiveGlobals.getProperty("httpbind.publicport.secure", JiveGlobals.getProperty("httpbind.port.secure", "7443"));
             response.getOutputStream().println("<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">");
             response.getOutputStream().println("  <Link rel=\"urn:xmpp:alt-connections:xbosh\" href=\"https://" + server + "/http-bind/\"/>");
             response.getOutputStream().println("  <Link rel=\"urn:xmpp:alt-connections:websocket\" href=\"wss://" + server + "/ws/\"/>");


### PR DESCRIPTION
Allow to override the anouced port of the XMPP server, `httpbind.port.secure` (with the default `7443`), by a public view  defined by `httpbind.publicport.secure`.

Fixes #157.