### PR TITLE
Update JitsiJvbWrapper.java

### DIFF
--- a/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -78,15 +78,13 @@ public class JitsiJvbWrapper implements ProcessListener
         String plain_port = JiveGlobals.getProperty( "ofmeet.websockets.plainport", "8180");
         if ("8080".equals(plain_port)) plain_port = "8180";
 
+        final String rest_port = JiveGlobals.getProperty( "ofmeet.videobridge.rest.port", "8188");
         final String public_port = JiveGlobals.getProperty( "httpbind.port.secure", "7443");
 
         String local_ip = JiveGlobals.getProperty( PluginImpl.MANUAL_HARVESTER_LOCAL_PROPERTY_NAME, ipAddress);
         String public_ip = JiveGlobals.getProperty( PluginImpl.MANUAL_HARVESTER_PUBLIC_PROPERTY_NAME, ipAddress);
         if (local_ip == null || local_ip.isEmpty()) local_ip = ipAddress;
         if (public_ip == null || public_ip.isEmpty()) public_ip = ipAddress;
-
-        final String rest_ip = JiveGlobals.getProperty( "ofmeet.videobridge.rest.address", local_ip.equals(public_ip) ? "locahost" : "0");
-        final String rest_port = JiveGlobals.getProperty( "ofmeet.videobridge.rest.port", "8188");
 
         List<String> lines = Arrays.asList(
             "videobridge {",
@@ -104,7 +102,6 @@ public class JitsiJvbWrapper implements ProcessListener
             "",
             "   http-servers {",
             "       private {",
-            "           host = " + rest_ip;
             "           port = " + rest_port;
             "       }",
             "       public {",

--- a/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -80,17 +80,13 @@ public class JitsiJvbWrapper implements ProcessListener
 
         final String public_port = JiveGlobals.getProperty( "httpbind.port.secure", "7443");
 
-        String keystore = JiveGlobals.getHomeDirectory() + File.separator + "resources" + File.separator + "security" + File.separator + "keystore";
         String local_ip = JiveGlobals.getProperty( PluginImpl.MANUAL_HARVESTER_LOCAL_PROPERTY_NAME, ipAddress);
         String public_ip = JiveGlobals.getProperty( PluginImpl.MANUAL_HARVESTER_PUBLIC_PROPERTY_NAME, ipAddress);
-
         if (local_ip == null || local_ip.isEmpty()) local_ip = ipAddress;
         if (public_ip == null || public_ip.isEmpty()) public_ip = ipAddress;
 
-        if(OSUtils.IS_WINDOWS)
-        {
-            keystore = keystore.replace("\\", "/");
-        }
+        final String rest_ip = JiveGlobals.getProperty( "ofmeet.videobridge.rest.address", local_ip.equals(public_ip) ? "localhost" : local_ip);
+        final String rest_port = JiveGlobals.getProperty( "ofmeet.videobridge.rest.port", "8188");
 
         List<String> lines = Arrays.asList(
             "videobridge {",
@@ -107,6 +103,10 @@ public class JitsiJvbWrapper implements ProcessListener
             "    }",
             "",
             "   http-servers {",
+            "       private {",
+            "           host = " + rest_ip;
+            "           port = " + rest_port;
+            "       }",
             "       public {",
             "           port = " + plain_port,
             "       }",

--- a/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -85,7 +85,7 @@ public class JitsiJvbWrapper implements ProcessListener
         if (local_ip == null || local_ip.isEmpty()) local_ip = ipAddress;
         if (public_ip == null || public_ip.isEmpty()) public_ip = ipAddress;
 
-        final String rest_ip = JiveGlobals.getProperty( "ofmeet.videobridge.rest.address", local_ip.equals(public_ip) ? "localhost" : local_ip);
+        final String rest_ip = JiveGlobals.getProperty( "ofmeet.videobridge.rest.address", local_ip.equals(public_ip) ? "locahost" : "0");
         final String rest_port = JiveGlobals.getProperty( "ofmeet.videobridge.rest.port", "8188");
 
         List<String> lines = Arrays.asList(

--- a/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -348,7 +348,7 @@ public class JitsiJvbWrapper implements ProcessListener
 
         try {
             HttpClient client = new DefaultHttpClient();
-            HttpGet get = new HttpGet("http://localhost:8080/colibri/stats");
+            HttpGet get = new HttpGet("http://localhost:" + rest_port + "/colibri/stats");
             HttpResponse response2 = client.execute(get);
             BufferedReader rd = new BufferedReader(new InputStreamReader(response2.getEntity().getContent()));
 


### PR DESCRIPTION
Note: The (internal) default binding for the JVB private interface is localhost. Bind to all interfaces if a `public_ip` is in use, because then there must be some external NAT and it should be save to allow access from the local net.

Also drop former used `keystore`

Support #182.