### PR TITLE
Feature list of meetings in progress

### DIFF
--- a/pade/src/i18n/pade_i18n.properties
+++ b/pade/src/i18n/pade_i18n.properties
@@ -40,7 +40,7 @@ global.click_test=Click to test...
 global.csrf.failed=CSRF Error: No changes made, you'll need to retry.
 
 # OFMeet specific properties start here.
-plugin.title=Pàdé
+plugin.title=PÃ dÃ©
 plugin.description=Unified Communications for Openfire
 plugin.jitsi.title=Jitsi
 plugin.freeswitch.title=FreeSWITCH
@@ -312,6 +312,10 @@ ofmeet.welcome.content.placeholder=Enter HTML to be displayed at bottom of welco
 ofmeet.welcomepage.toolbarcontent=Show Welcome Page Toolbar Content
 ofmeet.welcome.toolbarcontent=Welcome Page Toolbar Content
 ofmeet.welcome.toolbarcontent.placeholder=Enter HTML to be displayed on welcome page toolbar
+ofmeet.welcomepage.recentlist=Show Welcome Page Recent List
+ofmeet.welcomepage.inprogresslist=Show Welcome Page In Progress List
+ofmeet.welcomepage.inprogresslist.interval=Interval to refresh In Progress List (in seconds)
+ofmeet.welcomepage.inprogresslist.exclude=Room names that contain these keywords will not be displayed in the In Progress List (separate with :)
 ofmeet.welcomepage.title=Welcome Page Title
 ofmeet.welcomepage.title.placeholder=Enter text to be displayed as welcome title
 ofmeet.welcomepage.description=Welcome Page Description

--- a/pade/src/i18n/pade_i18n.properties
+++ b/pade/src/i18n/pade_i18n.properties
@@ -40,7 +40,7 @@ global.click_test=Click to test...
 global.csrf.failed=CSRF Error: No changes made, you'll need to retry.
 
 # OFMeet specific properties start here.
-plugin.title=PÃ dÃ©
+plugin.title=Pàdé
 plugin.description=Unified Communications for Openfire
 plugin.jitsi.title=Jitsi
 plugin.freeswitch.title=FreeSWITCH

--- a/pade/src/web/ofmeet-uisettings.jsp
+++ b/pade/src/web/ofmeet-uisettings.jsp
@@ -128,7 +128,16 @@
         final String welcomeDesc = ParamUtils.getParameter( request, "welcomeDesc" );          
         final String welcomeContent = ParamUtils.getParameter( request, "welcomeContent" );
         final String welcomeToolbarContent = ParamUtils.getParameter( request, "welcomeToolbarContent" );
-        
+        final boolean welcomeRecentList = ParamUtils.getBooleanParameter( request, "welcomepageRecentList" );
+        final boolean welcomeInProgressList = ParamUtils.getBooleanParameter( request, "welcomepageInProgressList" );
+        final String welcomeInProgressListInterval = request.getParameter( "welcomepageInProgressListInterval" );
+        try {
+            Integer.parseInt( welcomeInProgressListInterval );
+        } catch (NumberFormatException ex ) {
+            errors.put( "welcomeInProgressListInterval", "Cannot parse value as integer value." );
+        }
+        final String welcomeInProgressListExclude = ParamUtils.getParameter( request, "welcomepageInProgressListExclude" );
+
         final String language = ParamUtils.getParameter( request, "language" );                
         final boolean enableLanguageDetection = ParamUtils.getBooleanParameter( request, "enableLanguageDetection" );  
         
@@ -201,6 +210,10 @@
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.random.roomnames", Boolean.toString( randomRoomNames ) );            
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.content", Boolean.toString( welcomepageContent ) );            
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.toolbarcontent", Boolean.toString( welcomepageToolbarContent ) );            
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.recentlist", Boolean.toString( welcomeRecentList ) );
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist", Boolean.toString( welcomeInProgressList ) );
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.interval", welcomeInProgressListInterval );
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.exclude", welcomeInProgressListExclude );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.title",  welcomeTitle );     
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.description",  welcomeDesc );  
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcome.content",  welcomeContent );              
@@ -485,6 +498,26 @@
                     <input type="checkbox" name="welcomepageToolbarContent" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.welcomepage.toolbarcontent", false) ? "checked" : ""}>
                     <fmt:message key="ofmeet.welcomepage.toolbarcontent" />
                 </td>
+            </tr>
+            <tr>
+                <td nowrap colspan="2">
+                    <input type="checkbox" name="welcomepageRecentList" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.welcomepage.recentlist", true) ? "checked" : ""}>
+                    <fmt:message key="ofmeet.welcomepage.recentlist" />
+                </td>
+            </tr>
+            <tr>
+                <td nowrap colspan="2">
+                    <input type="checkbox" name="welcomepageInProgressList" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist", false) ? "checked" : ""}>
+                    <fmt:message key="ofmeet.welcomepage.inprogresslist" />
+                </td>
+            </tr>
+            <tr>
+                <td width="200"><fmt:message key="ofmeet.welcomepage.inprogresslist.interval" />:</td>
+                <td><input type="text" size="60" maxlength="100" name="welcomepageInProgressListInterval" value="${admin:getIntProperty("org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.interval", 10)}"></td>
+            </tr>
+            <tr>
+                <td width="200"><fmt:message key="ofmeet.welcomepage.inprogresslist.exclude" />:</td>
+                <td><input type="text" size="60" maxlength="100" name="welcomepageInProgressListExclude" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.exclude", "secret_")}"></td>
             </tr>
         </table>
     </admin:contentBox>

--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InProgressListServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InProgressListServlet.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.ofmeet;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.muc.*;
+import org.jivesoftware.util.JiveGlobals;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.JID;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.net.URL;
+import java.net.URLDecoder;
+
+/**
+ * A servlet that generates a snippet of json that is the 'conferences' variable, as used by the Jitsi
+ * Meet webapplication.
+ *
+ * @author Cool0707, cool0707@gmail.com
+ */
+public class InProgressListServlet extends HttpServlet
+{
+    /**
+     *
+     */
+    private static final long serialVersionUID = -9012313048172452140L;
+    private static final Logger Log = LoggerFactory.getLogger( InProgressListServlet.class );
+
+    public void doGet( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException
+    {
+        try
+        {
+            Log.trace( "[{}] conferences requested.", request.getRemoteAddr() );
+
+            response.setCharacterEncoding( "UTF-8" ); 
+            response.setContentType( "UTF-8" );
+            
+            String service = "conference"; //mainMuc.split(".")[0];
+            List<MUCRoom> rooms = XMPPServer.getInstance().getMultiUserChatManager().getMultiUserChatService(service).getChatRooms();        
+
+            URL requestUrl = new URL(request.getRequestURL().toString());
+
+            final JSONArray meetings = new JSONArray();
+
+            final String[] excludeKeywords = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.exclude", "").split(":");
+
+            for (MUCRoom chatRoom : rooms)
+            {
+                final JSONObject meeting = new JSONObject();
+
+                final JSONArray members = new JSONArray();
+                String focus = null;
+                String roomName = chatRoom.getJID().getNode();
+                String roomDecodedName = URLDecoder.decode(roomName, "UTF-8");
+                boolean bExclusion = false;
+
+                if ( roomName.equals("ofmeet") || roomName.equals("ofgasi") )
+                {
+                    continue;
+                }
+
+                for ( String keyword : excludeKeywords )
+                {
+                    if ( !keyword.isEmpty() && roomDecodedName.toLowerCase().contains(keyword.toLowerCase()) )
+                    {
+                        bExclusion = true;
+                        break;
+                    }
+                }
+
+                if ( bExclusion )
+                {
+                    continue;
+                }
+
+                for ( final MUCRole occupant : chatRoom.getOccupants() )
+                {
+                    JID jid = occupant.getUserAddress();
+                    String nick = jid.getNode();
+                    
+                    if (nick.equals("focus"))
+                    {
+                        focus = jid.getResource();
+                    }
+                    else
+                    {
+                        final JSONObject member = new JSONObject();
+
+                        member.put("id", occupant.getUserAddress().toBareJID());
+                        members.put(member);
+                    }
+                }
+
+                if (focus == null)
+                {
+                    continue;
+                }
+                
+                meeting.put( "name", roomDecodedName);
+                meeting.put( "url", new URL(requestUrl, "./" + roomName).toString());
+                meeting.put( "date", chatRoom.getCreationDate().getTime());
+                meeting.put( "members", members);
+                meeting.put( "password", StringUtils.isEmpty(chatRoom.getPassword())? "false" : "true" );
+
+                meetings.put(meeting);
+            }
+
+            // Add response headers that instruct not to cache this data.
+            response.setHeader( "Expires",       "Sat, 6 May 1995 12:00:00 GMT" );
+            response.setHeader( "Cache-Control", "no-store, no-cache, must-revalidate" );
+            response.addHeader( "Cache-Control", "post-check=0, pre-check=0" );
+            response.setHeader( "Pragma",        "no-cache" );
+            response.setHeader( "Content-Type",  "application/json" );
+            response.setHeader( "Connection",    "close" );
+
+            // Write out the JSON object.
+            response.getOutputStream().println(meetings.toString( 2 ));
+        }
+        catch ( Exception e )
+        {
+            Log.error( "[{}] Failed to generate meeting list!", request.getRemoteAddr(), e );
+        }
+    }
+}

--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
@@ -105,6 +105,10 @@ public class InterfaceConfigServlet extends HttpServlet
             config.put( "OFMEET_WELCOME_PAGE_TOOLBARCONTENT",    JiveGlobals.getProperty(        "org.jitsi.videobridge.ofmeet.welcome.toolbarcontent",        ""                  ) );
             config.put( "OFMEET_CRYPTPAD_URL",                   JiveGlobals.getProperty(        "org.jitsi.videobridge.ofmeet.cryptpad.url", "https://cryptpad.fr"                ) );
             config.put( "OFMEET_WHITEBOARD_URL",                 JiveGlobals.getProperty(        "org.jitsi.videobridge.ofmeet.whiteboard.url", "https://wbo.ophir.dev/boards/"    ) );
+            
+            config.put( "RECENT_LIST_ENABLED",                   JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.welcomepage.recentlist",        true                ) );
+            config.put( "IN_PROGRESS_LIST_ENABLED",              JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist",    false               ) );
+            config.put( "IN_PROGRESS_LIST_INTERVAL",             JiveGlobals.getIntProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.interval", 10                ) );
 
             config.put( "filmStripOnly",                         ofMeetConfig.getFilmstripOnly()      );
             config.put( "VERTICAL_FILMSTRIP",                    ofMeetConfig.getVerticalFilmstrip()  );

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -34,6 +34,16 @@
 		<url-pattern>/interface_config.js</url-pattern>
 	</servlet-mapping>
 
+	<servlet>
+		<servlet-name>inProgressList</servlet-name>
+		<servlet-class>org.jivesoftware.openfire.plugin.ofmeet.InProgressListServlet</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>inProgressList</servlet-name>
+		<url-pattern>/inProgressList.json</url-pattern>
+	</servlet-mapping>
+
 	<filter>
 		<filter-name>WatermarkFilter</filter-name>
 		<filter-class>org.jivesoftware.openfire.plugin.ofmeet.WatermarkFilter</filter-class>

--- a/web/src/main/webapp/lang/ofmeet-enGB.json
+++ b/web/src/main/webapp/lang/ofmeet-enGB.json
@@ -1,0 +1,6 @@
+{
+    "welcomepage": {
+        "inProgressList": "In Progress",
+        "inProgressListEmpty": "There are no meetings in progress."
+    }
+}

--- a/web/src/main/webapp/lang/ofmeet-ja.json
+++ b/web/src/main/webapp/lang/ofmeet-ja.json
@@ -1,0 +1,6 @@
+{
+    "welcomepage": {
+        "inProgressList": "開催中の会議",
+        "inProgressListEmpty": "開催中の会議はありません。"
+    }
+}


### PR DESCRIPTION
Fix Issue #186

Display the list of in-progress meetings on Welcome page.
Also, the following settings can be configured in the Admin Console.
- Show/hide the recent list
- Show/hide the current meeting list
- Refresh interval of the current meeting list
- Keywords of the room name to be excluded from the ongoing meeting list

In addition, I fixed the bug that the date in the recent list is not localized in some languages.
