### PR TITLE
Avoild creation of unused HttpClients

### DIFF
--- a/ofmeet/src/main/java/org/ifsoft/websockets/QueuedThreadPoolProvider.java
+++ b/ofmeet/src/main/java/org/ifsoft/websockets/QueuedThreadPoolProvider.java
@@ -1,0 +1,21 @@
+package org.ifsoft.websockets;
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+public class QueuedThreadPoolProvider {
+
+        private static final int MAX_THREADS = 1024;
+        private static final QueuedThreadPool queuedThreadPool;
+        
+        static {
+                queuedThreadPool = new QueuedThreadPool(MAX_THREADS,1);
+        }
+
+        public static QueuedThreadPool getQueuedThreadPool(String name) {
+                if (! queuedThreadPool.isRunning())
+                {
+                        queuedThreadPool.setName(name);
+                }
+                return queuedThreadPool;
+        }
+}

--- a/ofmeet/src/main/java/org/ifsoft/websockets/SslContextFactoryProvider.java
+++ b/ofmeet/src/main/java/org/ifsoft/websockets/SslContextFactoryProvider.java
@@ -1,0 +1,18 @@
+package org.ifsoft.websockets;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+public class SslContextFactoryProvider {
+        
+        private static final SslContextFactory.Client clientSslContextFactory;
+        
+        static {
+                clientSslContextFactory = new SslContextFactory.Client();
+                clientSslContextFactory.setValidateCerts(false);
+        }
+        
+        public static SslContextFactory.Client getClientSslContextFactory() {
+                return clientSslContextFactory;
+        }
+
+}


### PR DESCRIPTION
At the backend connection of the WebSocket reverse proxy, there's no need to have a pool of HttpClients as provided by default. Is because of the nature of WebSocket pragma to provide one continuously used connection for lifetime.

Use a common SslContextFactory, a common QueuedThreadPool and limit the provision of HttpClientTransports to one connection

Fixes #202