### PR TITLE
Fix lobby switch

### DIFF
--- a/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/LobbyMuc.java
+++ b/ofmeet/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/LobbyMuc.java
@@ -109,7 +109,7 @@ public class LobbyMuc implements ServerIdentitiesProvider, ServerFeaturesProvide
         jsonMsg.put("event", NOTIFY_LOBBY_ENABLED);
         jsonMsg.put("value", value);
         broadcast_json_msg(to, from, jsonMsg);
-        if (value) notify_configuration_change(from, to.toBareJID());
+        notify_configuration_change(from, to.toBareJID());
    }
 
     private void notify_lobby_access(JID room, JID from, String to, boolean granted)

--- a/pade/pom.xml
+++ b/pade/pom.xml
@@ -33,7 +33,7 @@
                     <configuration>
                         <url>https://download.jitsi.org/jitsi-meet/src/jitsi-meet-1.0.4641.tar.bz2</url>
                         <unpack>true</unpack>
-                        <outputDirectory>classes</outputDirectory>
+                        <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                     </configuration>
                     </execution>
                     <execution>
@@ -45,7 +45,7 @@
                     <configuration>
                         <url>https://github.com/igniterealtime/pade/raw/master/docs-1.6.13.4.zip</url>
                         <unpack>true</unpack>
-                        <outputDirectory>classes</outputDirectory>
+                        <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                     </configuration>
                     </execution>                    
                 </executions>
@@ -63,10 +63,10 @@
 
                     <configuration>
                     <overwrite>true</overwrite>                 
-                    <outputDirectory>classes/jitsi-meet</outputDirectory>
+                    <outputDirectory>${project.build.outputDirectory}/jitsi-meet</outputDirectory>
                     <resources>
                         <resource>
-                        <directory>../web/src/main/webapp</directory>
+                        <directory>${project.basedir}/../web/src/main/webapp</directory>
                         </resource>
                     </resources>
                     </configuration>
@@ -79,9 +79,9 @@
                     </goals>
                     <configuration>
                     <overwrite>true</overwrite>                 
-                    <outputDirectory>classes/docs</outputDirectory>
+                    <outputDirectory>${project.build.outputDirectory}/docs</outputDirectory>
                     <resources>                         
-                        <resource><directory>src/public</directory></resource>                                                
+                        <resource><directory>${project.basedir}/src/public</directory></resource>                                                
                     </resources>
                     </configuration>
                 </execution>                

--- a/web/src/main/webapp/libs/lib-jitsi-meet.min.js
+++ b/web/src/main/webapp/libs/lib-jitsi-meet.min.js
@@ -14050,6 +14050,7 @@
                     const c = $(e).find(">json-message").text();
                     if (c) {
                         const e = this.xmpp.tryParseJSONAndVerify(c);
+                        if (e && e.event === 'LOBBY-ENABLED' && e.type === 'lobby-notify' && !e.value) this.discoRoomInfo(); // COOL0707
                         if (e && void 0 === a) return void this.eventEmitter.emit(u.a.JSON_MESSAGE_RECEIVED, t, e)
                     }
                     r && ("chat" === i ? this.eventEmitter.emit(u.a.PRIVATE_MESSAGE_RECEIVED, t, n, r, this.myroomjid, a) : "groupchat" === i && this.eventEmitter.emit(u.a.MESSAGE_RECEIVED, t, n, r, this.myroomjid, a))

--- a/web/src/main/webapp/libs/lib-jitsi-meet.min.js
+++ b/web/src/main/webapp/libs/lib-jitsi-meet.min.js
@@ -14050,7 +14050,6 @@
                     const c = $(e).find(">json-message").text();
                     if (c) {
                         const e = this.xmpp.tryParseJSONAndVerify(c);
-                        if (e && e.event === 'LOBBY-ENABLED' && e.type === 'lobby-notify' && !e.value) this.discoRoomInfo(); // COOL0707
                         if (e && void 0 === a) return void this.eventEmitter.emit(u.a.JSON_MESSAGE_RECEIVED, t, e)
                     }
                     r && ("chat" === i ? this.eventEmitter.emit(u.a.PRIVATE_MESSAGE_RECEIVED, t, n, r, this.myroomjid, a) : "groupchat" === i && this.eventEmitter.emit(u.a.MESSAGE_RECEIVED, t, n, r, this.myroomjid, a))


### PR DESCRIPTION
Fix #159
- When the lobby is disabled, the server does not send the XMPP message of Status Codes 104, but uses another message instead.
- Rewrite the POM.xml directory to use properties, because GitPod sometimes fails to build Maven.