### PR TITLE
Brush up language selection

### DIFF
--- a/src/web/ofmeet-uisettings.jsp
+++ b/src/web/ofmeet-uisettings.jsp
@@ -394,6 +394,16 @@
                 </td>
             </tr>
            <tr>
+                <td width="200"><fmt:message key="config.page.configuration.language.title" /></td>
+        <td>
+                    <select name="language" required>
+                        <c:forEach items="${ofmeetConfig.languages}" var="language">
+                            <option name="language" value="${language.getCode()}" id="${language.getCode()}" ${(ofmeetConfig.language == language ? "selected" : "")}>${language}</option>
+                        </c:forEach>
+                </select>
+                </td>
+            </tr>            
+           <tr>
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableLanguageDetection" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.languagedetection", false) ? "checked" : ""}>
                     <fmt:message key="ofmeet.enable.languagedetection" />
@@ -488,24 +498,6 @@
         </table>
     </admin:contentBox>      
     
-    <fmt:message key="config.page.configuration.language.title" var="boxtitleLanguage"/>
-    <admin:contentBox title="${boxtitleLanguage}">
-        <table cellpadding="3" cellspacing="0" border="0" width="100%">
-            <tbody>
-            <c:forEach items="${ofmeetConfig.languages}" var="language">
-            <tr valign="top">
-                <td width="1%" nowrap>
-                    <input type="radio" name="language" value="${language.getCode()}" id="${language.getCode()}" ${(ofmeetConfig.language == language ? "checked" : "")}>
-                </td>
-                <td width="99%">
-                    <label for="${language.getCode()}">${language}</label>
-                </td>
-            </tr>
-            </c:forEach>
-            </tbody>
-        </table>
-    </admin:contentBox>
-
     <fmt:message key="ofmeet.welcome.title" var="boxtitleWelcome"/>
     <admin:contentBox title="${boxtitleWelcome}">
         <p><fmt:message key="ofmeet.welcome.description"/></p><br/>


### PR DESCRIPTION
Brush-up the client language selection at the Admin UI page `Pàdé|User Interface`: 
* Use a compact selection box instead of the long radio button list
* Move it to the section named _User Interface Configuration_ at top and drop former _Language_ section.

![image](https://user-images.githubusercontent.com/19855721/112182205-61e02b80-8bfd-11eb-9624-220f2d16d183.png)
