### PR TITLE
Let the Confetti Tool throw Single Emojis

### DIFF
--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -825,8 +825,10 @@ var ofmeet = (function(of)
             };
 
             if (text) {
+                const color = getRandomColor(APP.conference.getLocalDisplayName());
                 options = {
                     ...options,
+                    particleCount: 1, scalar: 5.0, colors: [ color ],
                     shapes: ['text:' + text]
                 };
             } else if ((new Date()).getMonth() == 11) {


### PR DESCRIPTION
Throw a single emoji from the palette, with a bigger size and the same color as used for the avatar circle background. This allow the others to identify the sender.

![image](https://user-images.githubusercontent.com/19855721/112659573-cd700600-8e54-11eb-8eea-19eb10a6534f.png)


@cool0707 Is this OK for you? If not, we may made this a switchable option at the AdminUI.