### PR TITLE
Support configuration of Etherpad at AdminUI

### DIFF
--- a/src/i18n/pade_i18n.properties
+++ b/src/i18n/pade_i18n.properties
@@ -255,6 +255,8 @@ ofmeet.default.local.displayname=Local Display Name
 ofmeet.tileview.columns.max=TileView Max Columns
 ofmeet.cryptpad.url=URL for CryptPad Service
 ofmeet.whiteboard.url=URL for Whiteboard Service
+ofmeet.etherpad.url=URL for Etherpad
+
 
 ofmeet.confetti.title=Conffeti Configuration
 ofmeet.confetti.description=Configuration of emoticon options for the confetti feature.
@@ -323,6 +325,7 @@ ofmeet.conference.recording=Record conference or desktop audio/video from Web Br
 ofmeet.conference.tags=Enable Tagged data to be shown as Captions/Subtitles
 ofmeet.enable.cryptpad=Enable CryptPad Collaboration Applications
 ofmeet.enable.whiteboard=Enable Collaborative Whiteboard
+ofmeet.enable.etherpad=Enable Etherpad
 ofmeet.enable.confetti=Enable Confetti Application
 ofmeet.cache.password=Cache User Password in Browser
 ofmeet.allow.uploads=Allow uploading of avatars and files for sharing with other participants

--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
@@ -84,8 +84,8 @@ public class ConfigServlet extends HttpServlet
             String recordingKey = null;
 
             int minHDHeight = JiveGlobals.getIntProperty( "org.jitsi.videobridge.ofmeet.min.hdheight", 540 );
-            int desktopSharingFrameRateMin = JiveGlobals.getIntProperty( "ofmeet.desktop.sharing.framerate.min", 5);			
-            int desktopSharingFrameRateMax = JiveGlobals.getIntProperty( "ofmeet.desktop.sharing.framerate.max", 25);					
+            int desktopSharingFrameRateMin = JiveGlobals.getIntProperty( "ofmeet.desktop.sharing.framerate.min", 5);            
+            int desktopSharingFrameRateMax = JiveGlobals.getIntProperty( "ofmeet.desktop.sharing.framerate.max", 25);                   
             String defaultLanguage = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.default.language", null );
             boolean useNicks = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.usenicks", false );
             boolean websockets = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.websockets", true );
@@ -108,9 +108,9 @@ public class ConfigServlet extends HttpServlet
             int startBitrate = JiveGlobals.getIntProperty( "org.jitsi.videobridge.ofmeet.start.bitrate", 800 );
             boolean logStats = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.stats.logging", false );
             String iceServers = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.iceservers", "" );
-            String xirsysUrl = JiveGlobals.getProperty( "ofmeet.xirsys.url", null ); 
+            String xirsysUrl = JiveGlobals.getProperty( "ofmeet.xirsys.url", null );
+            String etherpadBase = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.etherpad.url", null );
             boolean ofmeetWinSSOEnabled = JiveGlobals.getBooleanProperty( "ofmeet.winsso.enabled", false );
-            boolean ofmeetWebAuthnEnabled = JiveGlobals.getBooleanProperty( "ofmeet.webauthn.enabled", false );			
             boolean enablePreJoinPage = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.prejoin.page", false );
             boolean enableStereo = JiveGlobals.getBooleanProperty( "ofmeet.stereo.enabled", false );
             boolean enableAudioLevels = JiveGlobals.getBooleanProperty( "ofmeet.audioLevels.enabled", false );
@@ -131,10 +131,10 @@ public class ConfigServlet extends HttpServlet
             String minHeightForQualityLvlHigh = JiveGlobals.getProperty( "ofmeet.min.height.for.quality.level.high", "720" );
 
             String displayNotice = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.display.notice", "");
-			String ofmeetStreamKey = JiveGlobals.getProperty( "ofmeet.live.stream.key", "");
-			String ofmeetStreamPort = JiveGlobals.getProperty( "ofmeet.live.stream.port", "8080");			
-            boolean ofmeetLiveStream = JiveGlobals.getBooleanProperty( "ofmeet.live.stream.enabled", false);			
-			
+            String ofmeetStreamKey = JiveGlobals.getProperty( "ofmeet.live.stream.key", "");
+            String ofmeetStreamPort = JiveGlobals.getProperty( "ofmeet.live.stream.port", "8080");          
+            boolean ofmeetLiveStream = JiveGlobals.getBooleanProperty( "ofmeet.live.stream.enabled", false);            
+            
             boolean wsBridgeChannel = JiveGlobals.getBooleanProperty( "ofmeet.bridge.ws.channel", org.jitsi.util.OSUtils.IS_WINDOWS);
 
             if ( xirsysUrl != null )
@@ -261,9 +261,9 @@ public class ConfigServlet extends HttpServlet
             
             final JSONObject desktopSharingFrameRate = new JSONObject();
             desktopSharingFrameRate.put( "min", desktopSharingFrameRateMin );
-            desktopSharingFrameRate.put( "max", desktopSharingFrameRateMax );			
+            desktopSharingFrameRate.put( "max", desktopSharingFrameRateMax );           
             config.put( "desktopSharingFrameRate", desktopSharingFrameRate );
-			
+            
 
             // 'resolution' is used in some cases (chrome <61), newer versions use 'constraints'.
             config.put( "resolution", ofMeetConfig.getResolution() );
@@ -296,10 +296,9 @@ public class ConfigServlet extends HttpServlet
             config.put( "useRoomAsSharedDocumentName", false );
             config.put( "logStats", logStats );
             config.put( "ofmeetWinSSOEnabled", ofmeetWinSSOEnabled );
-			config.put( "ofmeetWebAuthnEnabled", ofmeetWebAuthnEnabled );
             config.put( "ofmeetStreamKey", ofmeetStreamKey );
-			config.put( "ofmeetLiveStream", ofmeetLiveStream );
-			config.put( "ofmeetStreamPort", ofmeetStreamPort );
+            config.put( "ofmeetLiveStream", ofmeetLiveStream );
+            config.put( "ofmeetStreamPort", ofmeetStreamPort );
 
             config.put( "conferences", conferences );
 
@@ -341,6 +340,11 @@ public class ConfigServlet extends HttpServlet
             config.put( "enableNoAudioDetection", true );
 
             config.put( "noticeMessage", displayNotice);
+
+            if ( etherpadBase != null && !etherpadBase.trim().isEmpty() )
+            {
+                config.put( "etherpad_base", etherpadBase.trim() );
+            }
 
             out.println( "var config = " + config.toString( 2 ) + ";" );
         }

--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
@@ -110,6 +110,7 @@ public class ConfigServlet extends HttpServlet
             String iceServers = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.iceservers", "" );
             String xirsysUrl = JiveGlobals.getProperty( "ofmeet.xirsys.url", null );
             String etherpadBase = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.etherpad.url", null );
+            boolean enableEtherpad = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.etherpad", false );
             boolean ofmeetWinSSOEnabled = JiveGlobals.getBooleanProperty( "ofmeet.winsso.enabled", false );
             boolean enablePreJoinPage = JiveGlobals.getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.prejoin.page", false );
             boolean enableStereo = JiveGlobals.getBooleanProperty( "ofmeet.stereo.enabled", false );
@@ -341,7 +342,7 @@ public class ConfigServlet extends HttpServlet
 
             config.put( "noticeMessage", displayNotice);
 
-            if ( etherpadBase != null && !etherpadBase.trim().isEmpty() )
+            if ( enableEtherpad && etherpadBase != null && !etherpadBase.trim().isEmpty() )
             {
                 config.put( "etherpad_base", etherpadBase.trim() );
             }

--- a/src/web/ofmeet-uisettings.jsp
+++ b/src/web/ofmeet-uisettings.jsp
@@ -44,6 +44,7 @@
 
         final String cryptpadurl = request.getParameter( "cryptpadurl" );
         final String whiteboardurl = request.getParameter( "whiteboardurl" );                
+        final String etherpadurl = request.getParameter( "etherpadurl" );                
 
         final String webappContextPath = request.getParameter( "webappcontextpath" );
         if ( webappContextPath != null && !StringUtils.escapeHTMLTags( webappContextPath ).equals( webappContextPath ) )
@@ -123,6 +124,7 @@
         final boolean conferenceTags = ParamUtils.getBooleanParameter( request, "conferenceTags" );
         final boolean enableCryptPad = ParamUtils.getBooleanParameter( request, "enableCryptPad" );    
         final boolean enableWhiteboard = ParamUtils.getBooleanParameter( request, "enableWhiteboard" );          
+        final boolean enableEtherpad = ParamUtils.getBooleanParameter( request, "enableEtherpad" );          
         final boolean enableConfetti = ParamUtils.getBooleanParameter( request, "enableConfetti" );          
         final boolean cachePassword = ParamUtils.getBooleanParameter( request, "cachePassword" );     
         final boolean showCaptions = ParamUtils.getBooleanParameter( request, "showCaptions" );        
@@ -226,6 +228,7 @@
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.conference.tags", Boolean.toString( conferenceTags ) );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.enable.cryptpad", Boolean.toString( enableCryptPad ) ); 
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.enable.whiteboard", Boolean.toString( enableWhiteboard ) );             
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.enable.etherpad", Boolean.toString( enableEtherpad ) );             
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.enable.confetti", Boolean.toString( enableConfetti ) );             
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.cache.password", Boolean.toString( cachePassword ) ); 
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.show.captions", Boolean.toString( showCaptions ) ); 
@@ -267,6 +270,7 @@
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.brand.show.watermark", Boolean.toString( brandShowWatermark ) );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.cryptpad.url", cryptpadurl );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.whiteboard.url", whiteboardurl );
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.etherpad.url", etherpadurl );
 
             ofmeetConfig.setWebappContextPath( webappContextPath );
             ofmeetConfig.setFilmstripMaxHeight( filmstripMaxHeight );
@@ -442,6 +446,10 @@
                 <td><input type="text" size="60" maxlength="100" name="whiteboardurl" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.whiteboard.url", "https://wbo.ophir.dev/boards/")}"></td>
             </tr>   
             <tr>
+                <td width="200"><fmt:message key="ofmeet.etherpad.url"/>:</td>
+                <td><input type="text" size="60" maxlength="100" name="etherpadurl" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.etherpad.url", "https://etherpad.wikimedia.org/p/")}"></td>
+            </tr>   
+            <tr>
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableCryptPad" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.cryptpad", true) ? "checked" : ""}>
                     <fmt:message key="ofmeet.enable.cryptpad" />
@@ -451,6 +459,12 @@
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableWhiteboard" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.whiteboard", true) ? "checked" : ""}>
                     <fmt:message key="ofmeet.enable.whiteboard" />
+                </td>
+            </tr>    
+            <tr>
+                <td nowrap colspan="2">
+                    <input type="checkbox" name="enableEtherpad" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.etherpad", true) ? "checked" : ""}>
+                    <fmt:message key="ofmeet.enable.etherpad" />
                 </td>
             </tr>    
             <tr>

--- a/src/web/ofmeet-uisettings.jsp
+++ b/src/web/ofmeet-uisettings.jsp
@@ -447,7 +447,7 @@
             </tr>   
             <tr>
                 <td width="200"><fmt:message key="ofmeet.etherpad.url"/>:</td>
-                <td><input type="text" size="60" maxlength="100" name="etherpadurl" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.etherpad.url", "https://etherpad.wikimedia.org/p/")}"></td>
+                <td><input type="text" size="60" maxlength="100" name="etherpadurl" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.etherpad.url", "https://board.net/p/")}"></td>
             </tr>   
             <tr>
                 <td nowrap colspan="2">


### PR DESCRIPTION
* Allow to configure the base-URL for external Etherpad and to enable this service at the AdminUI
* Pass the base-URL to the Jitsi Meet Webclient configuration (`.../config.js) if set and enabled.