### PR TITLE
Fix regression: Make Windows movable

### DIFF
--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -603,6 +603,11 @@ var ofmeet = (function (ofm) {
 
         console.debug("postJoinSetup");
 
+        // setup drag& drop
+        console.debug("add drag&drop handlers to local and participants windows");
+        addParticipantDragDropHandlers(document.getElementById("localVideoTileViewContainer"));
+        getOccupants();
+
         // custom events for show/hide toolbox
         const toolboxObserver = new MutationObserver(mutations => {
             mutations.forEach((mutation) => {


### PR DESCRIPTION
Fix regression of d3b8f9572765ddbdee5129f29c44aedba8760bcf: 
* code snippet to add handlers was lost
* the local window got a new Id.