### PR TITLE
Make Audio Level Indicators Switchable

### DIFF
--- a/src/i18n/pade_i18n.properties
+++ b/src/i18n/pade_i18n.properties
@@ -190,6 +190,8 @@ config.page.configuration.ofmeet.bitrates.low.max.bitrates.video=Maximum Bitrate
 config.page.configuration.ofmeet.bitrates.high.max.bitrates.video=Maximum Bitrate (high)
 config.page.configuration.ofmeet.bitrates.standard.max.bitrates.video=Maximum Bitrate (standard)
 
+config.page.configuration.ofmeet.audioLevels.enabled=Enable Audio Level Indicators
+config.page.configuration.ofmeet.audioLevels.circles=Use Avatar circle style
 config.page.configuration.ofmeet.stereo.enabled=Enable Stereo (No echo cancellation, use headset or audio device)
 config.page.configuration.record.path=Recording Path
 config.page.configuration.record.secret=Recording Password/Secret

--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/InterfaceConfigServlet.java
@@ -125,6 +125,10 @@ public class InterfaceConfigServlet extends HttpServlet
             config.put( "INVITE_OPTIONS",                        new JSONArray( ofMeetConfig.getInviteOptions() ) );
             config.put( "ENFORCE_NOTIFICATION_AUTO_DISMISS_TIMEOUT", "15000" );
 
+            if ( JiveGlobals.getBooleanProperty("ofmeet.audioLevels.enabled",false) && JiveGlobals.getBooleanProperty("ofmeet.audioLevels.circles",false) ) {
+                config.put("AUDIO_LEVEL_PRIMARY_COLOR", "rgba(255,255,255,0.4)");
+                config.put("AUDIO_LEVEL_SECONDARY_COLOR", "rgba(255,255,255,0.2)");
+            }
 
             // Jitsi-meet appears to have replaced LOCAL_THUMBNAIL_RATIO_WIDTH and LOCAL_THUMBNAIL_RATIO_HEIGHT with a combined value in LOCAL_THUMBNAIL_RATIO.
             final int localThumbnailRatioWidth  = JiveGlobals.getIntProperty("org.jitsi.videobridge.ofmeet.local.thumbnail.ratio.width",16 );

--- a/src/web/ofmeet-settings.jsp
+++ b/src/web/ofmeet-settings.jsp
@@ -183,6 +183,8 @@
         final boolean adaptivelastn = ParamUtils.getBooleanParameter( request, "adaptivelastn" );
         final boolean simulcast = ParamUtils.getBooleanParameter( request, "simulcast" );
         final boolean adaptivesimulcast = ParamUtils.getBooleanParameter( request, "adaptivesimulcast" );
+        final boolean enableAudioLevels = ParamUtils.getBooleanParameter( request, "enableAudioLevels" );
+        final boolean enableAudioLevelCircles = ParamUtils.getBooleanParameter( request, "enableAudioLevelCircles" );
         final boolean enableStereo = ParamUtils.getBooleanParameter( request, "enableStereo" );
         final boolean lipSync = ParamUtils.getBooleanParameter( request, "lipSync" );
         
@@ -193,6 +195,8 @@
 
         if ( errors.isEmpty() )
         {
+            JiveGlobals.setProperty( "ofmeet.audioLevels.enabled", Boolean.toString(enableAudioLevels) );
+            JiveGlobals.setProperty( "ofmeet.audioLevels.circles", Boolean.toString(enableAudioLevelCircles) );
             JiveGlobals.setProperty( "ofmeet.stereo.enabled", Boolean.toString(enableStereo) );
             JiveGlobals.setProperty( "ofmeet.winsso.enabled", Boolean.toString( securityenabled ) );
             JiveGlobals.setProperty( "ofmeet.webauthn.enabled", Boolean.toString( webauthn_enabled ) );         
@@ -523,6 +527,16 @@
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableStereo" ${admin:getBooleanProperty( "ofmeet.stereo.enabled", false) ? "checked" : ""}>
                     <fmt:message key="config.page.configuration.ofmeet.stereo.enabled"/>
+                </td>
+            </tr>            
+            <tr>
+                <td width="300" nowrap>
+                    <input type="checkbox" name="enableAudioLevels" ${admin:getBooleanProperty( "ofmeet.audioLevels.enabled", false) ? "checked" : ""}>
+                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.enabled"/>
+                </td>
+                <td nowrap>
+                    <input type="checkbox" name="enableAudioLevelCircles" ${admin:getBooleanProperty( "ofmeet.audioLevels.circles", false) ? "checked" : ""}>
+                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.circles"/>
                 </td>
             </tr>            
             <tr>

--- a/src/web/ofmeet-settings.jsp
+++ b/src/web/ofmeet-settings.jsp
@@ -183,8 +183,6 @@
         final boolean adaptivelastn = ParamUtils.getBooleanParameter( request, "adaptivelastn" );
         final boolean simulcast = ParamUtils.getBooleanParameter( request, "simulcast" );
         final boolean adaptivesimulcast = ParamUtils.getBooleanParameter( request, "adaptivesimulcast" );
-        final boolean enableAudioLevels = ParamUtils.getBooleanParameter( request, "enableAudioLevels" );
-        final boolean enableAudioLevelCircles = ParamUtils.getBooleanParameter( request, "enableAudioLevelCircles" );
         final boolean enableStereo = ParamUtils.getBooleanParameter( request, "enableStereo" );
         final boolean lipSync = ParamUtils.getBooleanParameter( request, "lipSync" );
         
@@ -195,8 +193,6 @@
 
         if ( errors.isEmpty() )
         {
-            JiveGlobals.setProperty( "ofmeet.audioLevels.enabled", Boolean.toString(enableAudioLevels) );
-            JiveGlobals.setProperty( "ofmeet.audioLevels.circles", Boolean.toString(enableAudioLevelCircles) );
             JiveGlobals.setProperty( "ofmeet.stereo.enabled", Boolean.toString(enableStereo) );
             JiveGlobals.setProperty( "ofmeet.winsso.enabled", Boolean.toString( securityenabled ) );
             JiveGlobals.setProperty( "ofmeet.webauthn.enabled", Boolean.toString( webauthn_enabled ) );         
@@ -527,16 +523,6 @@
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableStereo" ${admin:getBooleanProperty( "ofmeet.stereo.enabled", false) ? "checked" : ""}>
                     <fmt:message key="config.page.configuration.ofmeet.stereo.enabled"/>
-                </td>
-            </tr>            
-            <tr>
-                <td width="300" nowrap>
-                    <input type="checkbox" name="enableAudioLevels" ${admin:getBooleanProperty( "ofmeet.audioLevels.enabled", false) ? "checked" : ""}>
-                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.enabled"/>
-                </td>
-                <td nowrap>
-                    <input type="checkbox" name="enableAudioLevelCircles" ${admin:getBooleanProperty( "ofmeet.audioLevels.circles", false) ? "checked" : ""}>
-                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.circles"/>
                 </td>
             </tr>            
             <tr>

--- a/src/web/ofmeet-uisettings.jsp
+++ b/src/web/ofmeet-uisettings.jsp
@@ -103,6 +103,9 @@
             errors.put( "mousecursorTimeout", "Cannot parse value as long value." );
         }
 
+        final boolean enableAudioLevels = ParamUtils.getBooleanParameter( request, "enableAudioLevels" );
+        final boolean enableAudioLevelCircles = ParamUtils.getBooleanParameter( request, "enableAudioLevelCircles" );
+
         int filmstripMaxHeight = ofmeetConfig.getFilmstripMaxHeight();
         try {
             filmstripMaxHeight = Integer.parseInt( request.getParameter( "filmstripMaxHeight" ) );
@@ -264,6 +267,9 @@
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcome.content",  welcomeContent );              
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcome.toolbarcontent", welcomeToolbarContent );            
 
+            JiveGlobals.setProperty( "ofmeet.audioLevels.enabled", Boolean.toString(enableAudioLevels) );
+            JiveGlobals.setProperty( "ofmeet.audioLevels.circles", Boolean.toString(enableAudioLevelCircles) );
+
             JiveGlobals.setProperty( "ofmeet.feedback.enabled", Boolean.toString(enablefeedback) );
             JiveGlobals.setProperty( "ofmeet.feedback.description", descriptionMessage );
             JiveGlobals.setProperty( "ofmeet.feedback.placeholder", placeholderText );
@@ -416,9 +422,9 @@
                     <fmt:message key="ofmeet.random.roomnames.enabled" />
                 </td>
             </tr>
-           <tr>
+            <tr>
                 <td width="200"><fmt:message key="config.page.configuration.language.title" /></td>
-        <td>
+                <td>
                     <select name="language" required>
                         <c:forEach items="${ofmeetConfig.languages}" var="language">
                             <option name="language" value="${language.getCode()}" id="${language.getCode()}" ${(ofmeetConfig.language == language ? "selected" : "")}>${language}</option>
@@ -426,7 +432,7 @@
                 </select>
                 </td>
             </tr>            
-           <tr>
+            <tr>
                 <td nowrap colspan="2">
                     <input type="checkbox" name="enableLanguageDetection" ${admin:getBooleanProperty( "org.jitsi.videobridge.ofmeet.enable.languagedetection", false) ? "checked" : ""}>
                     <fmt:message key="ofmeet.enable.languagedetection" />
@@ -435,6 +441,16 @@
             <tr>
                 <td width="200"><fmt:message key="ofmeet.mousecursor.timeout"/>:</td>
                 <td><input type="text" size="10" maxlength="20" name="mousecursorTimeout" value="${admin:getLongProperty("org.jitsi.videobridge.ofmeet.mousecursor.timeout", 10000)}"></td>
+            </tr>
+            <tr>
+                <td width="200" nowrap>
+                    <input type="checkbox" name="enableAudioLevels" ${admin:getBooleanProperty( "ofmeet.audioLevels.enabled", false) ? "checked" : ""}>
+                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.enabled"/>
+                </td>
+                <td nowrap>
+                    <input type="checkbox" name="enableAudioLevelCircles" ${admin:getBooleanProperty( "ofmeet.audioLevels.circles", false) ? "checked" : ""}>
+                    <fmt:message key="config.page.configuration.ofmeet.audioLevels.circles"/>
+                </td>
             </tr>
         </table>
     </admin:contentBox>


### PR DESCRIPTION
Allow Audio Level Indicators at the Jitsi Webclient to be enabled at the Settings Page in the Admin UI. 
![image](https://user-images.githubusercontent.com/19855721/119971490-53254480-bfb1-11eb-907d-d076e82b5ca1.png)

Also allow to use the new _circle style_ animation.
![image](https://user-images.githubusercontent.com/19855721/119972076-13ab2800-bfb2-11eb-9ec5-c062904a831f.png)


