### PR TITLE
Introduce a Blacklist to Exclude Participants from the Meetings In Progress List

### DIFF
--- a/src/i18n/pade_i18n.properties
+++ b/src/i18n/pade_i18n.properties
@@ -351,6 +351,7 @@ ofmeet.welcomepage.recentlist=Show Page Recent List
 ofmeet.welcomepage.inprogresslist=Show Page In Progress List
 ofmeet.welcomepage.inprogresslist.interval=Interval to refresh In Progress List (in seconds)
 ofmeet.welcomepage.inprogresslist.exclude=Room names that contain these keywords will not be displayed in the In Progress List (separate with :)
+ofmeet.welcomepage.inprogresslist.excludeNicks=Account names that will not be displayed in the In Progress List (separate with :)
 ofmeet.welcomepage.inprogresslist.enable.size.info=Show Meeting Size Information
 ofmeet.welcomepage.inprogresslist.enable.participants.info=Show Meeting Participants Information
 ofmeet.welcomepage.inprogresslist.enable.protection.info=Show Protected Meeting Information

--- a/src/web/ofmeet-uisettings.jsp
+++ b/src/web/ofmeet-uisettings.jsp
@@ -171,6 +171,7 @@
             errors.put( "welcomeInProgressListInterval", "Cannot parse value as integer value." );
         }
         final String welcomeInProgressListExclude = ParamUtils.getParameter( request, "welcomepageInProgressListExclude" );
+        final String welcomeInProgressListExcludeNicks = ParamUtils.getParameter( request, "welcomepageInProgressListExcludeNicks" );
 
         final String language = ParamUtils.getParameter( request, "language" );                
         final boolean enableLanguageDetection = ParamUtils.getBooleanParameter( request, "enableLanguageDetection" );  
@@ -262,6 +263,7 @@
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.enableProtectionInfo", Boolean.toString( enableProtectionInfo ) );            
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.interval", welcomeInProgressListInterval );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.exclude", welcomeInProgressListExclude );
+            JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.excludeNicks", welcomeInProgressListExcludeNicks );
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.title",  welcomeTitle );     
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcomepage.description",  welcomeDesc );  
             JiveGlobals.setProperty( "org.jitsi.videobridge.ofmeet.welcome.content",  welcomeContent );              
@@ -630,6 +632,10 @@
             <tr>
                 <td width="200"><fmt:message key="ofmeet.welcomepage.inprogresslist.exclude" />:</td>
                 <td><input type="text" size="60" maxlength="100" name="welcomepageInProgressListExclude" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.exclude", "secret_")}"></td>
+            </tr>
+            <tr>
+                <td width="200"><fmt:message key="ofmeet.welcomepage.inprogresslist.excludeNicks" />:</td>
+                <td><input type="text" size="60" maxlength="100" name="welcomepageInProgressListExcludeNicks" value="${admin:getProperty("org.jitsi.videobridge.ofmeet.welcomepage.inprogresslist.excludeNicks", "")}"></td>
             </tr>
         </table>
     </admin:contentBox>


### PR DESCRIPTION
There already is a blacklist to hide certain meeting rooms from the "Meetings In Progress" list.

Introduce an analogous blacklist to hide certain participants (by accountname) from the member list of a meeting room.

![image](https://user-images.githubusercontent.com/19855721/120032744-ed5daa80-bffa-11eb-849e-db49b0f53d3e.png)
