### PR TITLE
[Enhancment] Allow External JVBs and NTLM SSO Under Linux

### DIFF
--- a/src/java/org/ifsoft/sso/Password.java
+++ b/src/java/org/ifsoft/sso/Password.java
@@ -17,6 +17,7 @@ import javax.servlet.ServletOutputStream;
 
 import java.io.*;
 import java.net.*;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
@@ -131,54 +132,52 @@ public class Password extends HttpServlet
         //no auth, request NTLM
         if (auth == null)
         {
-                response.setStatus(response.SC_UNAUTHORIZED);
-                response.setHeader("WWW-Authenticate", "NTLM");
-                return null;
+            response.setStatus(response.SC_UNAUTHORIZED);
+            response.setHeader("WWW-Authenticate", "NTLM");
+            return null;
         }
 
         //check what client sent
         if (auth.startsWith("NTLM "))
         {
-                byte[] msg = java.util.Base64.getDecoder().decode(auth.substring(5));
-                int off = 0, length, offset;
-                String s = null;
+            byte[] msg = java.util.Base64.getDecoder().decode(auth.substring(5));
 
-                if (msg[8] == 1) {
-                    byte z = 0;
-                    byte[] msg1 =
-                        {(byte)'N', (byte)'T', (byte)'L', (byte)'M', (byte)'S',(byte)'S', (byte)'P',
+            if (msg[8] == 1) {
+                byte z = 0;
+                byte[] msg1 =
+                    {(byte)'N', (byte)'T', (byte)'L', (byte)'M', (byte)'S',(byte)'S', (byte)'P',
                         z,(byte)2, z, z, z, z, z, z, z,
                         (byte)40, z, z, z, (byte)1, (byte)130, z, z,
                         z, (byte)2, (byte)2, (byte)2, z, z, z, z, //
                         z, z, z, z, z, z, z, z};
-                    // send ntlm type2 msg
+                // send ntlm type2 msg
 
-                    response.setStatus(response.SC_UNAUTHORIZED);
-                    String enc2 = new String(java.util.Base64.getEncoder().encode(msg1), "UTF-8");
-                    response.setHeader("WWW-Authenticate", "NTLM "+ enc2.trim());
-                    return null;
-                }
-                else if (msg[8] == 3) {
-                        off = 30;
-                        length = msg[off+17]*256 + msg[off+16];
-                        offset = msg[off+19]*256 + msg[off+18];
-                        s = new String(msg, offset, length, StandardCharsets.UTF_16LE);
-                        Log.debug("NTLMAuth Computer Name {}", s);
-                }
-                else {
-                    return null;
-                }
+                response.setStatus(response.SC_UNAUTHORIZED);
+                String enc2 = new String(java.util.Base64.getEncoder().encode(msg1), "UTF-8");
+                response.setHeader("WWW-Authenticate", "NTLM "+ enc2.trim());
+                return null;
+            }
+            else if (msg[8] == 3) {
+                int off = 30, length, offset;
+                Boolean unicode = (msg[60] & 0x1) == 1;
+                Charset encoding = unicode ? StandardCharsets.UTF_16LE : StandardCharsets.UTF_8;
+
                 length = msg[off+1]*256 + msg[off];
                 offset = msg[off+3]*256 + msg[off+2];
-                s = new String(msg, offset, length, StandardCharsets.UTF_16LE);
-                Log.debug("NTLMAuth Domain Name {}", s);
+                String domain = new String(msg, offset, length, encoding);
+                Log.debug("NTLMAuth Domain Name {}", domain);
+
+                length = msg[off+17]*256 + msg[off+16];
+                offset = msg[off+19]*256 + msg[off+18];
+                String wkstn = new String(msg, offset, length, encoding);
+                Log.debug("NTLMAuth Computer Name {}", wkstn);
 
                 length = msg[off+9]*256 + msg[off+8];
                 offset = msg[off+11]*256 + msg[off+10];
-
-                s = new String(msg, offset, length, StandardCharsets.UTF_16LE);
-                Log.debug("NTLMAuth User Name {}", s);
-                return s;
+                String username = new String(msg, offset, length, encoding);
+                Log.debug("NTLMAuth User Name {}", username);
+                return username;
+            }
         }
         return null;
     }

--- a/src/webapp/libs/lib-jitsi-meet.min.js
+++ b/src/webapp/libs/lib-jitsi-meet.min.js
@@ -6897,8 +6897,13 @@
 
 									if (token.indexOf(":") > -1 )
 									{
-										localStorage.setItem("ofmeet.access.token", token);	
-										window.location.reload();
+										localStorage.setItem("ofmeet.access.token", token);
+										//BUG? reload only if token changed to prevent infinite login loop for NTLM
+
+										if (!accessToken || accessToken !== token) {
+										    console.debug("SASLOFPade token has changed, reloading document");
+										    window.location.reload();
+										}
 									}
 
 								}).catch(function (err) {


### PR DESCRIPTION
These changes do the following:

1. Adds the ability to disable the built-in JVB.  By doing this, external JVBs can be utilized to help increase the scalability.  For example, we are using 3 external JVBs in this setup with the internal one disabled.
2. Fixes the NTLM implementation that was in the code for SSO on Linux.  Also has a change to remove the automatic document refresh when using SSO.  In our environment, leaving that part out would cause the meetings page to constantly refresh and not login properly via SSO.  My feeling is this issue does not happen when Openfire is run under Windows.

The external JVB has one issue I have not resolved yet, but plan to.  When using multiple JVBs, stats are currently only pulled from one of the systems.  My plan is to implement functionality to pull stats from all the JVBs and roll them up into a summary object in the getConferenceStats function.

Thanks for all the work you've put into this plugin!