### PR TITLE
Update JitsiJvbWrapper.java

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -96,7 +96,7 @@ public class JitsiJvbWrapper implements ProcessListener
             "        }",
             "        public {",
             "            port = " + plain_port,
-            "            host = " + JiveGlobals.getProperty( "ofmeet.videobridge.rest.host", public_ip),	
+            "            host = " + JiveGlobals.getProperty( "ofmeet.videobridge.rest.host", local_ip),	
             "        }",
             "    }",
             "",


### PR DESCRIPTION
The IP address used for `public` IP at the host tags introduced by 661e9f6 breaks the websocket proxying, because the JVB must use the **internal** IP (and our Proxy will offer the service to the **external** IP) . The Jitsi configuration tags `public` and `private` are somewhat misleading...

Will fix the regression in reopened #385.