### PR TITLE
Change shortcut used for Shared Mouse Pointer

### DIFF
--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -1074,7 +1074,7 @@ var ofmeet = (function (ofm) {
             id: 'ofmeet-cursor',
             icon: IMAGES.cursor,
             label: i18n('toolbar.shareCursorMousePointer'),
-            shortcut: 'P',
+            shortcut: '^',
             callback: (evt) => {
                 if (evt) evt.stopPropagation();
 

--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -1074,7 +1074,7 @@ var ofmeet = (function (ofm) {
             id: 'ofmeet-cursor',
             icon: IMAGES.cursor,
             label: i18n('toolbar.shareCursorMousePointer'),
-            shortcut: '^',
+            shortcut: '!',
             callback: (evt) => {
                 if (evt) evt.stopPropagation();
 


### PR DESCRIPTION
Old shortcut for "Share Mousepointer" ('P') now is used for the new Jitsi *Participants-Pane* feature. Change our to '^'.