### PR TITLE
Enhance WebPush feature

### DIFF
--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -417,6 +417,7 @@ var ofmeet = (function (ofm) {
 		room.on(JitsiMeetJS.events.conference.USER_JOINED, function (id) {
 			console.debug("user join", id, participants);
 			addParticipant(id);
+            publishWebPush();
 		});
 
 
@@ -3561,7 +3562,7 @@ var ofmeet = (function (ofm) {
     function handleSubscription(subscription, keys) {
         console.debug('handleSubscription', subscription, keys);
 
-        const secret = btoa(JSON.stringify({ privateKey: keys.privateKey, publicKey: keys.publicKey, subscription: subscription }));
+        const secret = btoa(JSON.stringify({ privateKey: keys.privateKey, publicKey: keys.publicKey, subscription: subscription, lastModified: Date.now() }));
         window.WebPushLib.setVapidDetails('xmpp:' + APP.connection.xmpp.connection.domain, keys.publicKey, keys.privateKey);
         window.WebPushLib.selfSecret = secret;
 
@@ -3581,14 +3582,10 @@ var ofmeet = (function (ofm) {
                 const secret = handleElement.innerHTML;
                 const id = Strophe.getResourceFromJid(message.getAttribute("from"));
                 const participant = APP.conference.getParticipantById(id);
-                const myName = getLocalDisplayName();
-
-                console.debug('webpush contact', id, participant);
 
                 if (participant && participant._displayName) {
+                    console.debug('webpush contact', id, participant, participant._displayName);
                     storage.setItem('pade.webpush.' + participant._displayName, atob(secret));
-                } else if (APP.conference.getMyUserId() == id && myName) {
-                    storage.setItem('pade.webpush.' + myName, atob(secret));
                 }
 
             }

--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -3586,6 +3586,8 @@ var ofmeet = (function (ofm) {
                 if (participant && participant._displayName) {
                     console.debug('webpush contact', id, participant, participant._displayName);
                     storage.setItem('pade.webpush.' + participant._displayName, atob(secret));
+                } else if (APP.conference.getMyUserId() == id) {
+                    // storage.setItem('pade.webpush._self' , atob(secret)); // activate this line for debugging
                 }
 
             }


### PR DESCRIPTION
* Don't add yourself to the Contacts Manager database. IMHO this is useless but will overwrite a webpush subscription made on another browser using the same account.
* Up to now, just the data of all participants joining **later than me** where added to the own contacts, but not the ones that were **already present** at time of own join. Now, broadcast own WebPush data if another participant is noticed to enter the room. This leads to the fact that this foreign participant (and all others)  will be served with the (recent) WebPush data of all present participants. 
* Add a lastModified timestamp to the WebPush data to know about it's age. This might be e.g. used as information in the Contacts Manager later.

Possible Enhancement: Instead of broadcasting to the room, the WebPush information might be send to just the other participant.