### PR TITLE
fix: problem with java execution (jdk11).

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJicofoWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJicofoWrapper.java
@@ -170,8 +170,9 @@ public class JitsiJicofoWrapper implements ProcessListener
             defaultOptions = "";
         }
 
-        final String customOptions = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.focus.jvm.customOptions", defaultOptions);
-        final String cmdLine = javaExec + " " + customOptions + " -Dconfig.file=" + configFile + " -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=" + jicofoHomePath + " -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=./logging.properties -Djdk.tls.ephemeralDHKeySize=2048 -cp ./jicofo-1.1-SNAPSHOT.jar" + File.pathSeparator + "./jicofo-1.1-SNAPSHOT-jar-with-dependencies.jar org.jitsi.jicofo.Main" + parameters;
+        String customOptions = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.focus.jvm.customOptions", defaultOptions);
+        if(!customOptions.isEmpty() && !customOptions.endsWith(" ")) customOptions += " ";
+        final String cmdLine = javaExec + " " + customOptions + "-Dconfig.file=" + configFile + " -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=" + jicofoHomePath + " -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=./logging.properties -Djdk.tls.ephemeralDHKeySize=2048 -cp ./jicofo-1.1-SNAPSHOT.jar" + File.pathSeparator + "./jicofo-1.1-SNAPSHOT-jar-with-dependencies.jar org.jitsi.jicofo.Main" + parameters;
         jicofoThread = Spawn.startProcess(cmdLine, new File(jicofoHomePath), this);
 
 		// create ofmeet muc room if it does not exist. needed for race condition when jicofo is a tls connection

--- a/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ofmeet/JitsiJvbWrapper.java
@@ -213,8 +213,9 @@ public class JitsiJvbWrapper implements ProcessListener
         writeProperties(props_file, local_ip, public_ip);
 
 
-        final String customOptions = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.jvb.jvm.customOptions", defaultOptions);
-        final String cmdLine = javaExec + " " + customOptions + " -Dconfig.file=" + configFile + " -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=" + jvbHomePath + " -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=./logging.properties -Djdk.tls.ephemeralDHKeySize=2048 -cp ./jitsi-videobridge-2.1-SNAPSHOT.jar" + File.pathSeparator + "./jitsi-videobridge-2.1-SNAPSHOT-jar-with-dependencies.jar org.jitsi.videobridge.MainKt  --apis=rest";
+        String customOptions = JiveGlobals.getProperty( "org.jitsi.videobridge.ofmeet.jvb.jvm.customOptions", defaultOptions);
+        if(!customOptions.isEmpty() && !customOptions.endsWith(" ")) customOptions += " ";
+        final String cmdLine = javaExec + " " + customOptions + "-Dconfig.file=" + configFile + " -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=" + jvbHomePath + " -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=./logging.properties -Djdk.tls.ephemeralDHKeySize=2048 -cp ./jitsi-videobridge-2.1-SNAPSHOT.jar" + File.pathSeparator + "./jitsi-videobridge-2.1-SNAPSHOT-jar-with-dependencies.jar org.jitsi.videobridge.MainKt  --apis=rest";
 
         if ( JiveGlobals.getBooleanProperty("ofmeet.use.internal.jvb", true) )
         {


### PR DESCRIPTION
@deleolajide 

In jdk11, there are two spaces after java.exe, and when I execute it with an array of String, I have confirmed that the problem that the execution class cannot be recognized occurs.
![image](https://user-images.githubusercontent.com/6185430/178888011-c4cb1171-b6b8-49d3-adee-94abda5e6c98.png)

* This only problem is if customOptions is blank.


**Sample code**
```
Runtime r = Runtime.getRuntime();
Process p = r.exec("C:\\AmazonCorretto\\jdk11.0.15_9\\bin\\java.exe  Test".split(" "));
InputStream in = p.getErrorStream();
System.out.println(new String(in.readAllBytes()));
```
```
* console log
Error: Could not find or load main class 
Caused by: java.lang.ClassNotFoundException:
```

**Environment**
  - OS: Windows
  - JDK: AmazonCorretto jdk11.0.15_9 ( jdk11 latest)
  - Openire: 4.7.1
  - pade: latest commit
 