### PR TITLE
Change character encoding for readme from ISO-8859 to UTF-8

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -67,7 +67,7 @@
 <li><a href="https://github.com/jitsi/jicofo">Jitsi Conference Focus (jicofo)</a> project;</li>
 <li><a href="https://github.com/jitsi/jitsi-meet">Jitsi Meet</a> web client.</li>
 <li><a href="https://github.com/jitsi/jigasi">Jitsi SIP Gateway</a> project.</li>
-<li><a href="https://github.com/igniterealtime/pade">Pàdé</a> web desktop client based on the <a href="https://github.com/conversejs/converse.js">ConverseJS</a> project.</li>
+<li><a href="https://github.com/igniterealtime/pade">PÃ dÃ©</a> web desktop client based on the <a href="https://github.com/conversejs/converse.js">ConverseJS</a> project.</li>
 <li><a href="https://www.ffmpeg.org/" rel="nofollow">ffmpeg</a> live streaming to rtmp server like you-tube.</li>
 </ul>
 <p dir="auto">Pade works with Firefox. It however works best with Chromium based apps like Chrome, Edge, Electron and Opera.</p>


### PR DESCRIPTION
This should help prevent issues with displaying the characters of the word `Pàdé`