### PR TITLE
fix firefox's unsupported codec error

### DIFF
--- a/src/webapp/custom_ofmeet.js
+++ b/src/webapp/custom_ofmeet.js
@@ -2608,6 +2608,24 @@ var ofmeet = (function (ofm) {
                 console.debug('ofmeet.js startDesktopRecorder - live streaming', tracks, ws_url);
 
                 let websocket = connectLiveStream("wss://" + ws_url[2] + "/livestream-ws/", config.ofmeetStreamKey);
+                //fix firefox's unsupported codec error
+                let mimeType = ''
+                //Safari not support isTypeSupported
+                if (MediaRecorder.isTypeSupported){
+                    mimeType= 'video/webm;codecs=h264'
+                    if (!MediaRecorder.isTypeSupported(mimeType)) {
+                        console.log(`${mimeType} is not Supported`);
+                        mimeType = "video/webm;codecs=vp9"
+                        if (!MediaRecorder.isTypeSupported(mimeType)) {
+                            console.log(`${mimeType} is not Supported`);
+                            mimeType = "video/webm" 
+                            if (!MediaRecorder.isTypeSupported(mimeType)) {
+                                console.log(`${mimeType} is not Supported`);
+                                mimeType = "" 
+                            }
+                        }
+                    }
+                }                
                 videoRecorder[id] = new MediaRecorder(recorderStreams[id], { mimeType: 'video/webm;codecs=h264', bitsPerSecond: 256 * 8 * 1024 });
 
                 videoRecorder[id].ondataavailable = function (e) {


### PR DESCRIPTION
fix firefox's unsupported codec error
```log
2023-11-30T03:43:21.127Z [JitsiMeetJS.ts] <getGlobalOnErrorHandler>:  UnhandledError: MediaRecorder constructor: video/webm;codecs=h264 indicates an unsupported codec Script: null Line: null Column: null StackTrace:  startDesktopRecorder/<@https://node2:7443/ofmeet/custom_ofmeet.js:3326:37
```